### PR TITLE
Return early if presenttabId doesn't match request tabId

### DIFF
--- a/app/content.ts
+++ b/app/content.ts
@@ -36,7 +36,7 @@ class Intercept {
     });
   };
   interceptSelected = (selectedReqs: Array<requestObject>) => {
-    if (selectedReqs.requestsToIntercept.length < 1) {
+    if (selectedReqs.requestsToIntercept.length < 1 || !selectedReqs.tabId || selectedReqs.requestsToIntercept.find( (req) => req.tabId !== selectedReqs.tabId )){
       return;
     }
     let responseTexts = selectedReqs.responseText || {};

--- a/app/content.ts
+++ b/app/content.ts
@@ -15,25 +15,27 @@ class Intercept {
       portName: "INTERCEPTOR"
     });
 
-    chrome.runtime.onMessage.addListener((request, _, __) => {
-      if (request.message === "INTERCEPT_CHECKED") {
-        this.interceptSelected(request);
-      } else if (request.message === "PAGE_REFRESHED") {
-        const presentState = bg_store.getState();
-        const checkedReqs = presentState.requests.filter(req => {
-          return presentState.checkedReqs[req.requestId] && request.tabId;
-        });
-        const requestObj = {
-          message: "INTERCEPT_ON_REFRESH",
-          requestsToIntercept: checkedReqs,
-          responseText: presentState.responseText,
-          statusCodes: presentState.statusCodes,
-          contentType: presentState.contentType,
-          tabId: request.tabId
-        };
-        this.interceptSelected(requestObj);
-      }
-    });
+    bg_store.ready().then( () => {
+      chrome.runtime.onMessage.addListener((request, _, __) => {
+        if (request.message === "INTERCEPT_CHECKED") {
+          this.interceptSelected(request);
+        } else if (request.message === "PAGE_REFRESHED") {
+          const presentState = bg_store.getState();
+          const checkedReqs = presentState.requests.filter(req => {
+            return presentState.checkedReqs[req.requestId] && request.tabId;
+          });
+          const requestObj = {
+            message: "INTERCEPT_ON_REFRESH",
+            requestsToIntercept: checkedReqs,
+            responseText: presentState.responseText,
+            statusCodes: presentState.statusCodes,
+            contentType: presentState.contentType,
+            tabId: request.tabId
+          };
+          this.interceptSelected(requestObj);
+        }
+      });
+    })
   };
   interceptSelected = (selectedReqs: Array<requestObject>) => {
     if (selectedReqs.requestsToIntercept.length < 1 || !selectedReqs.tabId || selectedReqs.requestsToIntercept.find( (req) => req.tabId !== selectedReqs.tabId )){


### PR DESCRIPTION
This PR returns early from the content-script and hence prevent creating unused variables if none of the request's tabId match the present tabId. 