### PR TITLE
Store current page number and page size of react-table in redux store

### DIFF
--- a/app/__tests__/request_list.test.jsx
+++ b/app/__tests__/request_list.test.jsx
@@ -4,7 +4,18 @@ import RequestList from "./../request_list";
 
 const commonProps = {
   handleIntercept: jest.fn(),
-  requests: []
+  requests: [],
+  PageDetails : {
+    100 : {
+      currentPageNumber : 0,
+      currentRowSize : 10
+    },
+    101 : {
+      currentPageNumber : 1,
+      currentRowSize : 5
+    }
+  },
+  tabId : 100
 };
 let wrapper;
 let RowComponent;

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -12,8 +12,7 @@ export const INTERCEPT_CHECKED = "INTERCEPT_CHECKED"
 export const STATUSCODE_CHANGE = "STATUSCODE_CHANGE"
 export const RESP_TEXT_CHANGE = "RESP_TEXT_CHANGE"
 export const CONTENT_TYPE_CHANGE = "CONTENT_TYPE_CHANGE"
-export const PAGE_NO_CHANGE = "PAGE_NO_CHANGE"
-export const ROW_SIZE_CHANGE = "ROW_SIZE_CHANGE"
+export const PAGINATION_CHANGE = "PAGINATION_CHANGE"
 
 // Action Creators
 export function startListening (enabledStatus:boolean){
@@ -49,9 +48,6 @@ export function handleRespTextChange(value:string, requestId:number){
 export function handleContentTypeChange(value:string, requestId:number){
   return {type : CONTENT_TYPE_CHANGE, payload : {value, requestId}}
 }
-export function handlePageNumberChange(currentPageNumber: string, tabId:number) {
-  return {type: PAGE_NO_CHANGE, payload: {currentPageNumber, tabId}};
-}
-export function handleRowSizeChange(currentRowSize: string, tabId:number) {
-  return {type: ROW_SIZE_CHANGE, payload: {currentRowSize, tabId}};
+export function handlePaginationChange(value: string, tabId:number, field:string) {
+  return {type: PAGINATION_CHANGE, payload: {field, value, tabId}};
 }

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -12,6 +12,8 @@ export const INTERCEPT_CHECKED = "INTERCEPT_CHECKED"
 export const STATUSCODE_CHANGE = "STATUSCODE_CHANGE"
 export const RESP_TEXT_CHANGE = "RESP_TEXT_CHANGE"
 export const CONTENT_TYPE_CHANGE = "CONTENT_TYPE_CHANGE"
+export const PAGE_NO_CHANGE = "PAGE_NO_CHANGE"
+export const ROW_SIZE_CHANGE = "ROW_SIZE_CHANGE"
 
 // Action Creators
 export function startListening (enabledStatus:boolean){
@@ -46,4 +48,10 @@ export function handleRespTextChange(value:string, requestId:number){
 }
 export function handleContentTypeChange(value:string, requestId:number){
   return {type : CONTENT_TYPE_CHANGE, payload : {value, requestId}}
+}
+export function handlePageNumberChange(currentPageNumber: string, tabId:number) {
+  return {type: PAGE_NO_CHANGE, payload: {currentPageNumber, tabId}};
+}
+export function handleRowSizeChange(currentRowSize: string, tabId:number) {
+  return {type: ROW_SIZE_CHANGE, payload: {currentRowSize, tabId}};
 }

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -26,7 +26,6 @@ chrome.tabs.query(queryParams, tabs => {
 
 
   store.ready().then(() => {
-    const state = store.getState();
     render(
       <Provider store={store} >
          <Popup tabUrl={url} tabId={id} />

--- a/app/modules/recordings.ts
+++ b/app/modules/recordings.ts
@@ -1,34 +1,76 @@
-import {POPUP_PROPS, Action} from '../types'
-export const INITIAL_POPUP_STATE : POPUP_PROPS = { enabled: false , errorMessage: "", requests: [], checkedReqs : {}, responseText: {}, statusCodes: {}, contentType: {}}
+import {POPUP_PROPS, Action} from "../types";
+export const INITIAL_POPUP_STATE: POPUP_PROPS = {
+  enabled: false,
+  tabId: -1,
+  tabUrl: "",
+  errorMessage: "",
+  requests: [],
+  checkedReqs: {},
+  responseText: {},
+  statusCodes: {},
+  contentType: {},
+  PageDetails: {}
+};
 
 //ACTION CONSTANTS
-import * as actionType from "../actions"
+import * as actionType from "../actions";
 
 export const reducer = (state = INITIAL_POPUP_STATE, action: Action) => {
   switch (action.type) {
     case actionType.START_LISTENING:
-      return {...state, enabled : action.payload}
+      return {...state, enabled: action.payload};
     case actionType.UPDATE_FIELD:
-      return {...state, [action.payload.name]: action.payload.value };
+      return {...state, [action.payload.name]: action.payload.value};
     case actionType.UPDATE_FIELDS:
-      return {...state,  ...action.payload};
+      return {...state, ...action.payload};
     case actionType.STOP_LISTENING:
       return {...state, enabled: action.payload};
     case actionType.ERROR:
-      return {...state, errorMessage: action.errorMessage, enabled:false }
-    case actionType.CLEAR_REQUESTS :
-      return {...state, requests: [] }
+      return {...state, errorMessage: action.errorMessage, enabled: false};
+    case actionType.CLEAR_REQUESTS:
+      return {...state, requests: []};
     case actionType.TOGGLE_CHECKBOX:
-      return {...state, checkedReqs: { ...state.checkedReqs, [action.reqId]: action.checked } }
-    case actionType.INTERCEPT_CHECKED :
-      return {...state}
+      return {...state, checkedReqs: {...state.checkedReqs, [action.reqId]: action.checked}};
+    case actionType.INTERCEPT_CHECKED:
+      return {...state};
     case actionType.RESP_TEXT_CHANGE:
-      return {...state, responseText: {...state.responseText, [action.payload.requestId] : action.payload.value}}
+      return {
+        ...state,
+        responseText: {...state.responseText, [action.payload.requestId]: action.payload.value}
+      };
     case actionType.STATUSCODE_CHANGE:
-        return {...state, statusCodes : {...state.statusCodes, [action.payload.requestId] : action.payload.value} }
+      return {
+        ...state,
+        statusCodes: {...state.statusCodes, [action.payload.requestId]: action.payload.value}
+      };
     case actionType.CONTENT_TYPE_CHANGE:
-      return {...state, contentType : {...state.contentType, [action.payload.requestId] : action.payload.value}}
+      return {
+        ...state,
+        contentType: {...state.contentType, [action.payload.requestId]: action.payload.value}
+      };
+    case actionType.PAGE_NO_CHANGE:
+      return {
+        ...state,
+        PageDetails: {
+          ...state.PageDetails,
+          [action.payload.tabId]: {
+            ...state.PageDetails[action.payload.tabId],
+            currentPageNumber: action.payload.currentPageNumber
+          }
+        }
+      };
+    case actionType.ROW_SIZE_CHANGE:
+      return {
+        ...state,
+        PageDetails: {
+          ...state.PageDetails,
+          [action.payload.tabId]: {
+            ...state.PageDetails[action.payload.tabId],
+            currentRowSize: action.payload.currentRowSize
+          }
+        }
+      };
     default:
       return state;
   }
-}
+};

--- a/app/modules/recordings.ts
+++ b/app/modules/recordings.ts
@@ -48,25 +48,14 @@ export const reducer = (state = INITIAL_POPUP_STATE, action: Action) => {
         ...state,
         contentType: {...state.contentType, [action.payload.requestId]: action.payload.value}
       };
-    case actionType.PAGE_NO_CHANGE:
+    case actionType.PAGINATION_CHANGE:
       return {
         ...state,
         PageDetails: {
           ...state.PageDetails,
           [action.payload.tabId]: {
             ...state.PageDetails[action.payload.tabId],
-            currentPageNumber: action.payload.currentPageNumber
-          }
-        }
-      };
-    case actionType.ROW_SIZE_CHANGE:
-      return {
-        ...state,
-        PageDetails: {
-          ...state.PageDetails,
-          [action.payload.tabId]: {
-            ...state.PageDetails[action.payload.tabId],
-            currentRowSize: action.payload.currentRowSize
+            [action.payload.field]: action.payload.value
           }
         }
       };

--- a/app/popup.tsx
+++ b/app/popup.tsx
@@ -16,7 +16,9 @@ import {
   handleCheckedRequests,
   handleRespTextChange,
   handleStatusCodeChange,
-  handleContentTypeChange
+  handleContentTypeChange,
+  handlePageNumberChange,
+  handleRowSizeChange
 } from "./actions";
 
 interface DispatchProps {
@@ -31,6 +33,8 @@ interface DispatchProps {
   handleRespTextChange: typeof handleRespTextChange;
   handleStatusCodeChange: typeof handleStatusCodeChange;
   handleContentTypeChange: typeof handleContentTypeChange;
+  handlePageNumberChange : typeof handlePageNumberChange;
+  handleRowSizeChange : typeof handleRowSizeChange;
 }
 
 const CHROME_URL_REGEX = /^chrome:\/\/.+$/;
@@ -41,6 +45,8 @@ const isChromeUrl = (url: string) => {
 
 export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
   componentWillMount() {
+    this.props.updateField("tabId", this.props.tabId);
+    this.props.updateField("tabUrl", this.props.tabUrl);
     MessageService.getRequests(this.props.tabId, requests => {
       this.props.updateField("requests", requests);
     });
@@ -102,6 +108,14 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
     );
   };
 
+  handlePageNumberChange = (newPageNo:string, tabId : number) => {
+    this.props.handlePageNumberChange(newPageNo, tabId)
+  }
+
+  handleRowSizeChange = (newPageSize:string,  tabId: number) => {
+    this.props.handleRowSizeChange(newPageSize, tabId)
+  }
+
   render() {
     const buttonClass = cx("button", {
       "button-start-listening": !this.props.enabled,
@@ -127,6 +141,10 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
           statusCodes={this.props.statusCodes}
           handleContentTypeChange={this.props.handleContentTypeChange}
           contentType={this.props.contentType}
+          handlePageNumberChange = {this.props.handlePageNumberChange}
+          handleRowSizeChange = {this.props.handleRowSizeChange}
+          PageDetails = {this.props.PageDetails}
+          tabId = {this.props.tabId}
         />
       </div>
     );
@@ -140,7 +158,8 @@ const mapStateToProps = (state: POPUP_PROPS) => ({
   checkedReqs: state.checkedReqs,
   responseText: state.responseText,
   statusCodes: state.statusCodes,
-  contentType: state.contentType
+  contentType: state.contentType,
+  PageDetails : state.PageDetails,
 });
 
 const mapDispatchToProps: DispatchProps = {
@@ -154,7 +173,9 @@ const mapDispatchToProps: DispatchProps = {
   handleCheckedRequests,
   handleStatusCodeChange,
   handleRespTextChange,
-  handleContentTypeChange
+  handleContentTypeChange,
+  handlePageNumberChange,
+  handleRowSizeChange
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Popup);

--- a/app/popup.tsx
+++ b/app/popup.tsx
@@ -17,8 +17,7 @@ import {
   handleRespTextChange,
   handleStatusCodeChange,
   handleContentTypeChange,
-  handlePageNumberChange,
-  handleRowSizeChange
+  handlePaginationChange
 } from "./actions";
 
 interface DispatchProps {
@@ -33,8 +32,7 @@ interface DispatchProps {
   handleRespTextChange: typeof handleRespTextChange;
   handleStatusCodeChange: typeof handleStatusCodeChange;
   handleContentTypeChange: typeof handleContentTypeChange;
-  handlePageNumberChange : typeof handlePageNumberChange;
-  handleRowSizeChange : typeof handleRowSizeChange;
+  handlePaginationChange: typeof handlePaginationChange
 }
 
 const CHROME_URL_REGEX = /^chrome:\/\/.+$/;
@@ -108,12 +106,8 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
     );
   };
 
-  handlePageNumberChange = (newPageNo:string, tabId : number) => {
-    this.props.handlePageNumberChange(newPageNo, tabId)
-  }
-
-  handleRowSizeChange = (newPageSize:string,  tabId: number) => {
-    this.props.handleRowSizeChange(newPageSize, tabId)
+  handlePaginationChange = (newPageNo_rowSize:string, tabId : number, field:string) => {
+    this.props.handlePaginationChange(newPageNo_rowSize, tabId, field)
   }
 
   render() {
@@ -141,8 +135,7 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
           statusCodes={this.props.statusCodes}
           handleContentTypeChange={this.props.handleContentTypeChange}
           contentType={this.props.contentType}
-          handlePageNumberChange = {this.props.handlePageNumberChange}
-          handleRowSizeChange = {this.props.handleRowSizeChange}
+          handlePaginationChange = {this.props.handlePaginationChange}
           PageDetails = {this.props.PageDetails}
           tabId = {this.props.tabId}
         />
@@ -174,8 +167,7 @@ const mapDispatchToProps: DispatchProps = {
   handleStatusCodeChange,
   handleRespTextChange,
   handleContentTypeChange,
-  handlePageNumberChange,
-  handleRowSizeChange
+  handlePaginationChange
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Popup);

--- a/app/request_list.tsx
+++ b/app/request_list.tsx
@@ -15,8 +15,7 @@ export interface RequestObj {
   handleContentTypeChange: React.FormEvent<HTMLSelectElement>;
   contentType: object;
   PageDetails: object;
-  handlePageNumberChange: React.MouseEvent<HTMLButtonElement>;
-  handleRowSizeChange: React.MouseEvent<HTMLSelectElement>;
+  handlePaginationChange: React.MouseEvent<HTMLButtonElement>;
   tabId: number;
 }
 const RequestList = (props: RequestObj) => {
@@ -98,8 +97,8 @@ const RequestList = (props: RequestObj) => {
       defaultPageSize={10}
       page={props.PageDetails[props.tabId] ? props.PageDetails[props.tabId].currentPageNumber : 0}
       pageSize={props.PageDetails[props.tabId] ? props.PageDetails[props.tabId].currentRowSize : 10}
-      onPageChange={changedPageNo => props.handlePageNumberChange(changedPageNo, props.tabId)}
-      onPageSizeChange={changedRowSize => props.handleRowSizeChange(changedRowSize, props.tabId)}
+      onPageChange={changedPageNo => props.handlePaginationChange(changedPageNo, props.tabId, "currentPageNumber")}
+      onPageSizeChange={changedRowSize => props.handlePaginationChange(changedRowSize, props.tabId, "currentRowSize")}
       freezeWhenExpanded={true}
       SubComponent={row => (
         <InterceptForm

--- a/app/request_list.tsx
+++ b/app/request_list.tsx
@@ -6,14 +6,18 @@ import {InterceptForm} from "./Intercept_Components";
 export interface RequestObj {
   requests: Array<chrome.webRequest.WebRequestDetails>;
   handleCheckToggle: React.ChangeEvent<HTMLInputElement>;
-  handleCheckedRequests:React.MouseEventHandler<HTMLButtonElement>;
-  handleRespTextChange : React.FormEvent<HTMLInputElement>;
+  handleCheckedRequests: React.MouseEventHandler<HTMLButtonElement>;
+  handleRespTextChange: React.FormEvent<HTMLInputElement>;
   handleStatusCodeChange: React.FormEvent<HTMLSelectElement>;
-  checkedReqs : Array<any>;
-  responseText: Array<any>
-  statusCodes : Array<any>
+  checkedReqs: object;
+  responseText: object;
+  statusCodes: object;
   handleContentTypeChange: React.FormEvent<HTMLSelectElement>;
-  contentType:Array<any>;
+  contentType: object;
+  PageDetails: object;
+  handlePageNumberChange: React.MouseEvent<HTMLButtonElement>;
+  handleRowSizeChange: React.MouseEvent<HTMLSelectElement>;
+  tabId: number;
 }
 const RequestList = (props: RequestObj) => {
   const columns = [
@@ -50,30 +54,36 @@ const RequestList = (props: RequestObj) => {
     {
       id: "checkbox",
       accessor: "",
-      Cell: ({ original }) => {
+      Cell: ({original}) => {
         return (
           <input
             type="checkbox"
             className="checkbox"
             checked={props.checkedReqs[original.requestId]}
-            onChange={(e) => {
-              props.handleCheckToggle(original.requestId, e.target.checked)}
-            }
+            onChange={e => {
+              props.handleCheckToggle(original.requestId, e.target.checked);
+            }}
           />
         );
       },
       Header: "Intercept",
       sortable: false,
       width: 45,
-      Footer: ({data}) =>(
+      Footer: ({data}) => (
         <span>
-          <button id="intercept-all-btn" onClick={() => {
-            const enabledRequests = data.filter((request) => {
-              return props.checkedReqs[request.checkbox.requestId]
-            })
-            .map(request => request.checkbox);
-            props.handleCheckedRequests(enabledRequests)
-          }}>Intercept All</button>
+          <button
+            id="intercept-all-btn"
+            onClick={() => {
+              const enabledRequests = data
+                .filter(request => {
+                  return props.checkedReqs[request.checkbox.requestId];
+                })
+                .map(request => request.checkbox);
+              props.handleCheckedRequests(enabledRequests);
+            }}
+          >
+            Intercept All
+          </button>
         </span>
       )
     }
@@ -85,11 +95,23 @@ const RequestList = (props: RequestObj) => {
       showPagination={true}
       showPaginationTop={false}
       showPaginationBottom={true}
-      pageSize={10}
-      freezeWhenExpanded
+      defaultPageSize={10}
+      page={props.PageDetails[props.tabId] ? props.PageDetails[props.tabId].currentPageNumber : 0}
+      pageSize={props.PageDetails[props.tabId] ? props.PageDetails[props.tabId].currentRowSize : 10}
+      onPageChange={changedPageNo => props.handlePageNumberChange(changedPageNo, props.tabId)}
+      onPageSizeChange={changedRowSize => props.handleRowSizeChange(changedRowSize, props.tabId)}
+      freezeWhenExpanded={true}
       SubComponent={row => (
-        <InterceptForm freezeWhenExpanded={true} rowProps={row} handleStatusCodeChange={props.handleStatusCodeChange} handleRespTextChange={props.handleRespTextChange} responseText={props.responseText}
-        statusCodes={props.statusCodes} handleContentTypeChange={props.handleContentTypeChange} contentType={props.contentType} />
+        <InterceptForm
+          freezeWhenExpanded={true}
+          rowProps={row}
+          handleStatusCodeChange={props.handleStatusCodeChange}
+          handleRespTextChange={props.handleRespTextChange}
+          responseText={props.responseText}
+          statusCodes={props.statusCodes}
+          handleContentTypeChange={props.handleContentTypeChange}
+          contentType={props.contentType}
+        />
       )}
     />
   );

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,13 +1,14 @@
 export interface POPUP_PROPS {
-  tabId : number,
-  tabUrl : string,
-  enabled : boolean,
-  requests : Array<any>,
-  errorMessage : string,
-  checkedReqs : object,
-  statusCodes: Array<any>
-  responseText: Array<any>
-  contentType:Array<any>
+  tabId : number
+  tabUrl : string
+  enabled : boolean
+  requests : Array<any>
+  errorMessage : string
+  checkedReqs : object
+  statusCodes: object
+  responseText: object
+  contentType: object
+  PageDetails : object
 }
 
 export interface selectCheckBoxes{
@@ -24,7 +25,7 @@ export interface PopUpState {
   statusCodes:object;
 }
 
-export interface Action{
+export interface Action extends POPUP_PROPS{
   name ?: string
   value ?: any
   type: string


### PR DESCRIPTION
This PR stores the current  page number and page-size of react-table with tabId as the key in redux store so that the page numbers and size do not reset to default values when we change tabs or close the popup.

Fixes #55 