### PR TITLE
Show the entire URL as title

### DIFF
--- a/app/components/request_list.tsx
+++ b/app/components/request_list.tsx
@@ -23,8 +23,7 @@ const RequestList = (props: RequestObj) => {
   const columns = [
     {
       Header: "Request URL",
-      className: "url",
-      accessor: "url",
+      Cell: ({original}) => <div style={{flex: '100 0 auto', width: '100px'}}className="url" title={original.url}>{original.url}</div>,
       filterable: true,
       filterMethod: (filter, rows) => {
         return matchSorter(rows, filter.value, {

--- a/app/components/request_list.tsx
+++ b/app/components/request_list.tsx
@@ -23,7 +23,7 @@ const RequestList = (props: RequestObj) => {
   const columns = [
     {
       Header: "Request URL",
-      Cell: ({original}) => <div style={{flex: '100 0 auto', width: '100px'}}className="url" title={original.url}>{original.url}</div>,
+      Cell: ({original}) => <div className="url" title={original.url}>{original.url}</div>,
       filterable: true,
       filterMethod: (filter, rows) => {
         return matchSorter(rows, filter.value, {

--- a/app/stylesheets/styles.css
+++ b/app/stylesheets/styles.css
@@ -23,3 +23,7 @@
 .popup {
   width: 100%;
 }
+.url{
+  flex: 100px 0 auto;
+  width: 100px
+}


### PR DESCRIPTION
Show the entire URL as title. Useful when the user wants to know the entire URL on hovering instead of dragging the table across