### PR TITLE
Remove default Response-text and let users type own mock response

### DIFF
--- a/app/__tests__/intercept_box.test.jsx
+++ b/app/__tests__/intercept_box.test.jsx
@@ -49,7 +49,7 @@ describe("Input and select Field tests", () => {
     });
 
     test("default value for response text", () => {
-      expect(wrapper.find(".responseText").props().defaultValue).toEqual("{msg:hello}");
+      expect(wrapper.find(".responseText").props().defaultValue).toEqual("");
     });
     test("default value for status text", () => {
       expect(wrapper.find(".select-status").props().value).toEqual("200");

--- a/app/components/Intercept_Components/InterceptTextBox.tsx
+++ b/app/components/Intercept_Components/InterceptTextBox.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export const InterceptTextBox = props => {
-  const defaultResponseText = "{msg:hello}";
+  const defaultResponseText = "";
   const defaultStatusCode = "200";
   const defaultContentType = "application/json";
   const responseTextValue = props.responseText[props.rowProps.checkbox.requestId] || defaultResponseText;

--- a/app/content/content.ts
+++ b/app/content/content.ts
@@ -56,7 +56,7 @@ class Intercept {
 
   setDefaultValues = (responseField, requestsToIntercept, defaultResponseValue) => {
       requestsToIntercept.forEach(req => {
-        if (!(responseField[req.requestId] && responseField[req.requestId].trim())) {
+        if (!(responseField[req.requestId])) {
           responseField[req.requestId] = defaultResponseValue;
         }
       });
@@ -67,7 +67,7 @@ class Intercept {
     let responseTexts = selectedReqs.responseText || {};
     let statusCodes = selectedReqs.statusCodes || {};
     let contentType = selectedReqs.contentType || {};
-    this.setDefaultValues(responseTexts,selectedReqs.requestsToIntercept, `{msg : "hello"}`)
+    this.setDefaultValues(responseTexts,selectedReqs.requestsToIntercept, "")
     this.setDefaultValues(statusCodes,selectedReqs.requestsToIntercept, "200")
     this.setDefaultValues(contentType,selectedReqs.requestsToIntercept, "application/json")
 


### PR DESCRIPTION
Earlier if the response text specified in the `textarea` was blank, such requests were responded with default text. This PR allows interceptor to mock empty `fake` responses