### PR TITLE
Display full URL in subcomponent

### DIFF
--- a/app/components/Intercept_Components/InterceptTextBox.tsx
+++ b/app/components/Intercept_Components/InterceptTextBox.tsx
@@ -12,9 +12,10 @@ export const InterceptTextBox = props => {
     <div className="grid-container form">
       <div className="full-url">
         <label htmlFor="">URL</label>
-        <div
+        <a
+          href={props.rowProps.checkbox.url}
           className="urlText"
-        >{props.rowProps.checkbox.url}</div>
+        >{props.rowProps.checkbox.url}</a>
       </div>
       <div className="response">
         <label htmlFor="">Response Text</label>

--- a/app/components/Intercept_Components/InterceptTextBox.tsx
+++ b/app/components/Intercept_Components/InterceptTextBox.tsx
@@ -10,6 +10,12 @@ export const InterceptTextBox = props => {
 
   return (
     <div className="grid-container form">
+      <div className="full-url">
+        <label htmlFor="">URL</label>
+        <div
+          className="urlText"
+        >{props.rowProps.checkbox.url}</div>
+      </div>
       <div className="response">
         <label htmlFor="">Response Text</label>
         <textarea

--- a/app/components/request_list.tsx
+++ b/app/components/request_list.tsx
@@ -101,6 +101,7 @@ const RequestList = (props: RequestObj) => {
     <ReactTable
       data={props.requests}
       columns={columns}
+      resizable={false}
       showPagination={true}
       showPaginationTop={false}
       showPaginationBottom={true}

--- a/app/components/request_list.tsx
+++ b/app/components/request_list.tsx
@@ -101,7 +101,6 @@ const RequestList = (props: RequestObj) => {
     <ReactTable
       data={props.requests}
       columns={columns}
-      resizable={false}
       showPagination={true}
       showPaginationTop={false}
       showPaginationBottom={true}

--- a/app/stylesheets/_grid.css
+++ b/app/stylesheets/_grid.css
@@ -30,3 +30,10 @@ header .grid-container {
   grid-row: 2;
   grid-column: 2;
 }
+.full-url{
+  grid-row: 3;
+  grid-row-end: 3;
+}
+.urlText{
+  max-width: 300px;
+}

--- a/app/stylesheets/_grid.css
+++ b/app/stylesheets/_grid.css
@@ -32,8 +32,8 @@ header .grid-container {
 }
 .full-url{
   grid-row: 3;
-  grid-row-end: 3;
+  grid-column: 1/3;
 }
 .urlText{
-  max-width: 300px;
+  word-break: break-all;
 }

--- a/app/stylesheets/styles.css
+++ b/app/stylesheets/styles.css
@@ -25,6 +25,7 @@
   width: 100%;
 }
 .url{
-  flex: 100px 0 auto;
-  width: 100px
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
A better approach to fix #86 . Displays the complete URL in expanded state instead of having to look at whole URL by resizing the table
![screen shot 2018-04-05 at 2 52 26 pm](https://user-images.githubusercontent.com/5921327/38357729-05157968-38e1-11e8-8f0e-cb43a36d77f0.png)
