### PR TITLE
Better URL filtering

### DIFF
--- a/app/containers/popup.tsx
+++ b/app/containers/popup.tsx
@@ -85,13 +85,7 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
   };
 
   handleCheckedRequests = (requests: Array<object>) => {
-    MessageService.interceptChecked(
-      this.props.tabId,
-      requests,
-      this.props.responseText,
-      this.props.statusCodes,
-      this.props.contentType
-    );
+    MessageService.interceptChecked(this.props.tabId, requests);
   };
 
   handlePaginationChange = (newPageNo_rowSize: string, tabId: number, field: string) => {

--- a/app/content/content.ts
+++ b/app/content/content.ts
@@ -100,14 +100,14 @@ class Intercept {
                const incomingUrl = url
                const requestUrl = new URL(request.url)
                const host = requestUrl.host
-               //const urlpathName = requestUrl.pathname;
-               console.log("INCLUDES", request.url.includes(url))
-               if(!request.url.includes(url)){
+               const urlpathName = requestUrl.pathname;
+               console.log("INCLUDES", request.url.includes(requestUrl.pathname))
+               if(request.url.includes(url)){
                 return true
                }
              })
              console.log(!result)
-             return result
+             return !result
            });
            this.server.respondWith((xhr, id) => {
              const respondUrl = requestArray.requestsToIntercept.find((request) => {

--- a/app/message_service.ts
+++ b/app/message_service.ts
@@ -1,4 +1,3 @@
-/// <reference path="../node_modules/@types/chrome/chrome-app.d.ts" />
 import { RequestObj } from "./components/request_list";
 export type GenericCallback = (_: any) => void;
 
@@ -35,8 +34,8 @@ export function getCount(tabId: number, callback: GenericCallback) {
 export function clearData(tabId: number) {
   chrome.runtime.sendMessage({ message: "CLEAR_DATA", tabId });
 }
-export function interceptChecked(tabId:number, requests:Array<any>, responseText:Array<any>, statusCodes:Array<any>, contentType:Array<any>){
-  chrome.tabs.sendMessage(tabId, {message: "INTERCEPT_CHECKED", requestsToIntercept:requests, responseText, statusCodes, contentType, tabId} )
+export function interceptChecked(tabId:number, requests:Array<any>){
+  chrome.tabs.sendMessage(tabId, {message: "INTERCEPT_CHECKED", requestsToIntercept:requests, tabId} )
 }
 // TODO: Extract message handlers from background.js and content_script.js
 // into this class and use callbacks to register message handlers


### PR DESCRIPTION
This PR implements a better URL filtering in the `addFilter` method of `sinon`. Also, it fixes an issue where the old responses were being used for interception even though the user specified an updated response. This is done by fetching the latest `redux` store state in the `content` script itself rather than passing the response from UI through `message passing`