### PR TITLE
Disable redux-logger in production builds

### DIFF
--- a/app/store/popup_store.ts
+++ b/app/store/popup_store.ts
@@ -8,18 +8,20 @@ export interface PopUpInterface {
   errorMessage ?: string;
   requests?: Array<Object>;
 }
-
+let enhancer:any;
+if (process.env.NODE_ENV !== 'production') {
 const logger:Middleware = createLogger();
 
 const middlewares = applyMiddleware(logger);
-const enhancer = compose(
+enhancer = compose(
   middlewares
 );
-
-export default function (initalState: PopUpInterface ) {
-  return createStore(reducer , initalState, enhancer);
 }
 
-
-
-
+export default function (initalState: PopUpInterface ) {
+  if(enhancer){
+    return createStore(reducer , initalState, enhancer)
+  }else{
+    return createStore(reducer , initalState)
+  }
+}


### PR DESCRIPTION
Since logging of redux actions are not needed in `production builds`, avoid using `redux-logger` middleware. 