### PR TITLE
Courier font for responsetext field

### DIFF
--- a/app/stylesheets/_form.css
+++ b/app/stylesheets/_form.css
@@ -139,7 +139,7 @@ input[type="text"],
 input[type="search"], textarea {
   display: block;
   width: 100%;
-  padding: 0 12px;
+  padding: 0 5px;
   color: var(--primary-text-color);
   background-color: var(--primary-color-text);
   background-image: none;
@@ -186,4 +186,5 @@ label {
 }
 .responseText{
   font-family: "Courier New", Courier, monospace;
+  line-height: 1.2;
 }

--- a/app/stylesheets/_form.css
+++ b/app/stylesheets/_form.css
@@ -184,3 +184,6 @@ label {
 .response-action {
   margin: 10px 15px;
 }
+.responseText{
+  font-family: "Courier New", Courier, monospace;
+}


### PR DESCRIPTION
Makes the line-height a bit narrower and uses the `courier` or `monospace` font 

![screen shot 2018-04-06 at 7 50 48 pm](https://user-images.githubusercontent.com/5921327/38426300-ecb97ace-39d3-11e8-973e-f6eddec646fb.png)
