### PR TITLE
Initialise thunk and alias middleware for prod builds

### DIFF
--- a/app/store/popup_store.ts
+++ b/app/store/popup_store.ts
@@ -1,33 +1,24 @@
-import { createStore, applyMiddleware } from 'redux'
-import { createLogger } from 'redux-logger'
-import { Middleware } from 'react-redux/node_modules/redux';
-import thunkMiddleware from 'redux-thunk';
-import aliases from './aliases'
-import { alias } from 'react-chrome-redux';
-
-import {reducer}  from './../reducers/rootReducer';
+import {createStore, applyMiddleware} from "redux";
+import {createLogger} from "redux-logger";
+import {Middleware} from "react-redux/node_modules/redux";
+import thunkMiddleware from "redux-thunk";
+import aliases from "./aliases";
+import {alias} from "react-chrome-redux";
+import {reducer} from "./../reducers/rootReducer";
 export interface PopUpInterface {
   enabled: boolean;
-  errorMessage ?: string;
+  errorMessage?: string;
   requests?: Array<Object>;
 }
-let enhancer:any;
-if (process.env.NODE_ENV !== 'production') {
-const logger:Middleware = createLogger({
-  collapsed: true,
-})
-
-enhancer = applyMiddleware(
-  alias(aliases),
-	thunkMiddleware,
-	logger
-);
+let enhancer: any;
+if (process.env.NODE_ENV !== "production") {
+  const logger: Middleware = createLogger({
+    collapsed: true
+  });
+  enhancer = applyMiddleware(alias(aliases), thunkMiddleware, logger);
+} else {
+  enhancer = applyMiddleware(alias(aliases), thunkMiddleware);
 }
-
-export default function (initalState: PopUpInterface ) {
-  if(enhancer){
-    return createStore(reducer , initalState, enhancer)
-  }else{
-    return createStore(reducer , initalState)
-  }
+export default function(initalState: PopUpInterface) {
+  return createStore(reducer, initalState, enhancer);
 }


### PR DESCRIPTION
Fixes a bug due to which `thunk` and `alias` middleware weren't getting applied in prod builds