### PR TITLE
Display dynamic tooltip instead of static text for toggling Interceptor

### DIFF
--- a/app/components/Switch.tsx
+++ b/app/components/Switch.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 
 export const Switch: React.SFC<Switch> = props => {
   let classNames = ["switch", props.isOn ? "switch_is-on" : "switch_is-off"].join(" ");
+  let interceptLabelText = props.isOn ? "Disable Interception" : "Enable Interception";
   return (
     <div className="toggle-switch-container">
-      <span>Toggle Interception</span>
       <div className={classNames} onClick={props.handleSwitchToggle}>
-        <ToggleButton isOn={props.isOn} />
+        <div className="tooltip" data-tooltip={interceptLabelText}>
+          <ToggleButton isOn={props.isOn} />
+        </div>
       </div>
     </div>
   );

--- a/app/stylesheets/styles.css
+++ b/app/stylesheets/styles.css
@@ -160,3 +160,37 @@
   text-align: center;
   padding: 5px;
 }
+
+/*Tooltip Styles */
+
+.tooltip {
+  position: relative;
+  color: #3B627E;
+  font-weight: bolder;
+  cursor: pointer;
+}
+.tooltip:hover::before {
+  content: "";
+  border: solid transparent;
+  border-bottom-color: #4862A3;
+  border-width: 10px;
+  position: absolute;
+  top: 11px;
+  left: 16px;
+}
+.tooltip:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  min-width: 15em;
+  font-weight: 600;
+  line-height: 1.3em;
+  margin: 0;
+  background: #3a539b;
+  color: #fff;
+  padding: 6px;
+  border-radius: 5px;
+  left: 10%;
+  top: 29px;
+  z-index: 1;
+  font-size: 2.7em;
+}


### PR DESCRIPTION
Earlier

![Earlier](https://github.com/code-mancers/interceptor/blob/Tooltip-enable-disable-toggle/images/interceptor_ui.png?raw=true)

Now
![Enable](https://user-images.githubusercontent.com/5921327/43246237-9969084c-90ce-11e8-8e2e-9606d529f674.png)
![Disable](https://user-images.githubusercontent.com/5921327/43246241-99ffc30e-90ce-11e8-9384-411ca3f9b78b.png)
