### PR TITLE
Add rule : Separate reducers

### DIFF
--- a/app/__tests__/AddRuleModal.test.jsx
+++ b/app/__tests__/AddRuleModal.test.jsx
@@ -1,15 +1,12 @@
 import * as React from "react";
 import { shallow } from "enzyme";
-import { AddRuleModal } from "./../components/AddRuleModal";
+import AddRuleModal  from "./../components/AddRuleModal";
 
 const createTestProps = props => ({
+  addRequestDetails:{ fields : {url : "http://www.codemancers.com", method: "GET", error:""}},
+  updateAddRequestFields: jest.fn(),
   handleClose: jest.fn(),
-  addRequestMethod: "GET",
-  addRequest: jest.fn(),
-  addRequestUrl: "http://www.codemancers.com",
-  updateAddRequestMethod: jest.fn(),
-  updateAddRequestUrl: jest.fn(),
-  addRuleErrorNotify:jest.fn(),
+  updateRequest: jest.fn(),
   tabId: 4545
   // allow to override common props
   ...props
@@ -41,38 +38,33 @@ describe("AddRuleModal component test", () => {
         .find("input")
         .first()
         .simulate("change", { target: { value: "a" } });
-      expect(props.updateAddRequestUrl).toHaveBeenCalledTimes(1);
+      expect(props.updateAddRequestFields).toHaveBeenCalledTimes(1);
     });
     test("onChange method input", ()=> {
       wrapper
       .find("select")
       .first()
       .simulate("change", { target: { value: "a" } });
-    expect(props.updateAddRequestMethod).toHaveBeenCalledTimes(1);
+    expect(props.updateAddRequestFields).toHaveBeenCalledTimes(1);
     });
 
-    test("onClick of addRule button and for Valid URL, props.addRequest must be called with proper params and reset fields", ()=> {
+    test("onClick of addRule button and for Valid URL, props.addRequest must be called with proper params", ()=> {
       wrapper
       .find(".btn-add-rule")
       .first()
       .simulate("click");
-    //to clear out the earlier error message
-    expect(props.addRuleErrorNotify).toHaveBeenCalledWith("", 4545)
-    expect(props.addRequest).toHaveBeenCalledTimes(1);
-    expect(props.addRequest).toHaveBeenCalledWith("http://www.codemancers.com", "GET")
-    //to reset url and method fields to empty strings
-    expect(props.updateAddRequestUrl).toHaveBeenCalledWith("",4545)
-    expect(props.updateAddRequestMethod).toHaveBeenCalledWith("GET", 4545)
+    expect(props.updateRequest).toHaveBeenCalledTimes(1);
+    //expect(props.updateRequest).toHaveBeenCalledWith("http://www.codemancers.com", "GET")
     });
 
-    test("onClick of addRule button and for Valid URL, props.addRuleErrorNotify must be called", ()=> {
-      const wrapperWithInvalidUrl = shallow(<AddRuleModal {...props} addRequestUrl="www.codemancers.com" /> );
+    test("onClick of addRule button and for invalid URL, props.addRuleErrorNotify must be called", ()=> {
+      const wrapperWithInvalidUrl = shallow(<AddRuleModal {...props} addRequestDetails={{fields : {url : "www.codemancers.com", method: "GET", error:""}}} />    );
       wrapperWithInvalidUrl
       .find(".btn-add-rule")
       .first()
       .simulate("click");
-    expect(props.addRuleErrorNotify).toHaveBeenCalled();
-    expect(props.addRuleErrorNotify).toHaveBeenCalledWith("Please Enter a valid URL", 4545)
+    expect(props.updateAddRequestFields).toHaveBeenCalled();
+    expect(props.updateAddRequestFields).toHaveBeenCalledWith("www.codemancers.com", "GET", "Please Enter a valid URL")
     });
 })
 

--- a/app/__tests__/AddRuleModal.test.jsx
+++ b/app/__tests__/AddRuleModal.test.jsx
@@ -7,7 +7,7 @@ const createTestProps = props => ({
   updateAddRequestFields: jest.fn(),
   handleClose: jest.fn(),
   updateRequest: jest.fn(),
-  tabId: 4545
+  tabId: 4545,
   // allow to override common props
   ...props
 });
@@ -39,13 +39,15 @@ describe("AddRuleModal component test", () => {
         .first()
         .simulate("change", { target: { value: "a" } });
       expect(props.updateAddRequestFields).toHaveBeenCalledTimes(1);
+      expect(props.updateAddRequestFields).toHaveBeenCalledWith("a", "GET", "");
     });
     test("onChange method input", ()=> {
       wrapper
       .find("select")
       .first()
-      .simulate("change", { target: { value: "a" } });
+      .simulate("change", { target: { value: "POST" } });
     expect(props.updateAddRequestFields).toHaveBeenCalledTimes(1);
+    expect(props.updateAddRequestFields).toHaveBeenCalledWith("http://www.codemancers.com", "POST", "");
     });
 
     test("onClick of addRule button and for Valid URL, props.addRequest must be called with proper params", ()=> {
@@ -54,7 +56,6 @@ describe("AddRuleModal component test", () => {
       .first()
       .simulate("click");
     expect(props.updateRequest).toHaveBeenCalledTimes(1);
-    //expect(props.updateRequest).toHaveBeenCalledWith("http://www.codemancers.com", "GET")
     });
 
     test("onClick of addRule button and for invalid URL, props.addRuleErrorNotify must be called", ()=> {
@@ -63,6 +64,7 @@ describe("AddRuleModal component test", () => {
       .find(".btn-add-rule")
       .first()
       .simulate("click");
+    expect(props.updateRequest).toHaveBeenCalledTimes(0);
     expect(props.updateAddRequestFields).toHaveBeenCalled();
     expect(props.updateAddRequestFields).toHaveBeenCalledWith("www.codemancers.com", "GET", "Please Enter a valid URL")
     });

--- a/app/__tests__/popup.test.jsx
+++ b/app/__tests__/popup.test.jsx
@@ -7,7 +7,6 @@ import * as MessageService from "../message_service";
 jest.mock("../message_service");
 const createTestProps = props => ({
   tabRecord: {
-    showAddRequest: true,
     PageDetails: [],
     checkedReqs: {},
     enabledStatus: false,
@@ -16,6 +15,8 @@ const createTestProps = props => ({
     isInterceptorOn: true,
     requests: []
   },
+  showAddRuleModal: true,
+  addRequestDetails: {fields : { url : "codemancers.com", method: "GET", error: ""}},
   currentTab: 1,
   currentUrl: "http://www.google.com",
   clearFields: jest.fn(),

--- a/app/__tests__/popup.test.jsx
+++ b/app/__tests__/popup.test.jsx
@@ -16,7 +16,7 @@ const createTestProps = props => ({
     requests: []
   },
   showAddRuleModal: true,
-  addRequestDetails: {fields : { url : "codemancers.com", method: "GET", error: ""}},
+  addRequestDetails: { fields: { url: "codemancers.com", method: "GET", error: "" } },
   currentTab: 1,
   currentUrl: "http://www.google.com",
   clearFields: jest.fn(),
@@ -29,7 +29,7 @@ const createTestProps = props => ({
   handleStatusCodeChange: jest.fn(),
   toggleListeningRequests: jest.fn(),
   updateInterceptorStatus: jest.fn(),
-  clearFields: jest.fn()
+  clearFields: jest.fn(),
   // allow to override common props
   ...props
 });
@@ -151,11 +151,11 @@ describe("Popup", () => {
       expect(wrapper.find("#success-msg").exists()).toBeFalsy();
     });
 
-    test ('on clear button click, should trigger props.clearFields', () => {
-      let localProps = createTestProps ();
-      wrapper = mount (<Popup {...localProps} />);
-      wrapper.find ('.btn-clear').simulate ('click');
-      expect (localProps.clearFields).toBeCalledWith (1);
+    test("on clear button click, should trigger props.clearFields", () => {
+      let localProps = createTestProps();
+      wrapper = mount(<Popup {...localProps} />);
+      wrapper.find(".btn-clear").simulate("click");
+      expect(localProps.clearFields).toBeCalledWith(1);
     });
   });
 });

--- a/app/actions/addRequest.ts
+++ b/app/actions/addRequest.ts
@@ -1,0 +1,16 @@
+export const RESET = "RESET";
+export const UPDATE_REQUEST_FIELDS = "UPDATE_REQUEST_FIELDS";
+export const UPDATE_FIELD = "UPDATE_FIELD";
+
+export const updateAddRequestFields = (name, value) => {
+  return {
+    type: UPDATE_REQUEST_FIELDS,
+    payload: { name, value }
+  };
+};
+
+export const resetAddRequest = () => {
+  return {
+    type: RESET
+  };
+};

--- a/app/actions/addRequest.ts
+++ b/app/actions/addRequest.ts
@@ -1,11 +1,10 @@
 export const RESET = "RESET";
 export const UPDATE_REQUEST_FIELDS = "UPDATE_REQUEST_FIELDS";
-export const UPDATE_FIELD = "UPDATE_FIELD";
 
-export const updateAddRequestFields = (name, value) => {
+export const updateAddRequestFields = (url: string, method: string, error: string) => {
   return {
     type: UPDATE_REQUEST_FIELDS,
-    payload: { name, value }
+    payload: { url, method, error }
   };
 };
 

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -97,10 +97,10 @@ export const updateAddRequestUrl = (value: string, tabId: number) => {
   };
 };
 
-export const toggleAddRequestForm = (showAddRequest: boolean, tabId: number) => {
+export const toggleAddRequestForm = (showAddRuleModal: boolean) => {
   return {
     type: TOGGLE_SHOW_ADD_REQUEST,
-    payload: { showAddRequest, tabId }
+    payload: { showAddRuleModal }
   };
 };
 

--- a/app/actions/index.ts
+++ b/app/actions/index.ts
@@ -14,19 +14,14 @@ export const FETCH_DATA_FAILURE = "FETCH_DATA_FAILURE";
 export const UPDATE_REQUEST = "UPDATE_REQUEST";
 export const TOGGLE_LISTENING = "TOGGLE_LISTENING";
 export const INITIALISE_DEFAULTS = "INITIALISE_DEFAULTS";
-export const HANDLE_MODAL_METHOD_CHANGE = "HANDLE_MODAL_METHOD_CHANGE";
-export const HANDLE_MODAL_URL_CHANGE = "HANDLE_MODAL_URL_CHANGE";
 export const TOGGLE_SHOW_ADD_REQUEST = "TOGGLE_SHOW_ADD_REQUEST";
 export const CHANGE_URL_TABLE = "CHANGE_URL_TABLE";
-export const ADD_RULE_ERROR = "ADD_RULE_ERROR";
 
 // Action Creators
 export function errorNotify(errorMessage: string, tabId: number) {
   return { type: ERROR, payload: { errorMessage, tabId } };
 }
-export function addRuleErrorNotify(errorMessage: string, tabId: number) {
-  return { type: ADD_RULE_ERROR, payload: { errorMessage, tabId } };
-}
+
 export function clearFields(tabId: number) {
   return { type: CLEAR_REQUESTS, payload: { tabId } };
 }
@@ -83,27 +78,12 @@ export function initialiseDefaults(
   };
 }
 
-export const updateAddRequestMethod = (value: string, tabId: number) => {
-  return {
-    type: HANDLE_MODAL_METHOD_CHANGE,
-    payload: { value, tabId }
-  };
-};
-
-export const updateAddRequestUrl = (value: string, tabId: number) => {
-  return {
-    type: HANDLE_MODAL_URL_CHANGE,
-    payload: { value, tabId }
-  };
-};
-
 export const toggleAddRequestForm = (showAddRuleModal: boolean) => {
   return {
     type: TOGGLE_SHOW_ADD_REQUEST,
     payload: { showAddRuleModal }
   };
 };
-
 export const handleChangeUrl = (value: string, tabId: number, index: number) => {
   return { type: CHANGE_URL_TABLE, payload: { value, tabId, index } };
 };

--- a/app/background/background.ts
+++ b/app/background/background.ts
@@ -2,7 +2,7 @@ import { wrapStore } from "react-chrome-redux";
 
 import { INITIAL_POPUP_STATE } from "./../reducers/rootReducer";
 import createStore from "./../store/popup_store";
-export const store = createStore({ ...INITIAL_POPUP_STATE });
+export const store = createStore({ rootReducer: INITIAL_POPUP_STATE });
 import { toggleListeningRequests, updateRequest } from "./../actions";
 
 interface TabRecord {

--- a/app/components/AddRuleModal.tsx
+++ b/app/components/AddRuleModal.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import { connect } from "react-redux";
-
+import * as uuid from "uuid";
 import { Modal } from "./ModalWrapper";
-import { updateAddRequestFields } from "./../actions/addRequest";
 
 interface AddRuleModalProps {
   addRequestDetails: Object;
@@ -11,7 +9,7 @@ interface AddRuleModalProps {
   tabId: number;
   updateRequest: (tabId: number, request: chrome.webRequest.WebRequestBodyDetails) => void;
 }
-class AddRuleModal extends React.PureComponent<AddRuleModalProps, {}> {
+export default class AddRuleModal extends React.PureComponent<AddRuleModalProps, {}> {
   isUrl = (str: string) => {
     try {
       new URL(str);
@@ -115,18 +113,3 @@ class AddRuleModal extends React.PureComponent<AddRuleModalProps, {}> {
     );
   }
 }
-
-const mapStateToProps = (state: POPUP_PROPS) => {
-  return {
-    ...state.addRequestReducer
-  };
-};
-
-const mapDispatchToProps = {
-  updateAddRequestFields
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(AddRuleModal);

--- a/app/containers/Popup.tsx
+++ b/app/containers/Popup.tsx
@@ -183,6 +183,7 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
               addRequestDetails={props.addRequestDetails}
               updateRequest={props.updateRequest}
               tabId={props.currentTab}
+              updateAddRequestFields={props.updateAddRequestFields}
             />
           )}
 

--- a/app/containers/Popup.tsx
+++ b/app/containers/Popup.tsx
@@ -8,6 +8,7 @@ import { Logo } from "../components/Logo";
 import RequestList from "../components/RequestList";
 import { POPUP_PROPS } from "../types";
 import * as actionTypes from "../actions";
+import { updateAddRequestFields } from "../actions/addRequest";
 //icons
 import { PlayIcon } from "../components/Icons/PlayIcon";
 import { StopIcon } from "../components/Icons/StopIcon";
@@ -110,7 +111,7 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
   };
 
   toggleAddRequestForm = () => {
-    this.props.toggleAddRequestForm(!this.props.tabRecord.showAddRequest, this.props.currentTab);
+    this.props.toggleAddRequestForm(!this.props.showAddRuleModal);
   };
 
   render() {
@@ -179,17 +180,11 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
             </div>
           </div>
 
-          {tabRecord.showAddRequest && (
+          {props.showAddRuleModal && (
             <AddRuleModal
               handleClose={this.toggleAddRequestForm}
-              updateAddRequestUrl={props.updateAddRequestUrl}
-              updateAddRequestMethod={props.updateAddRequestMethod}
-              addRequest={this.addRequest}
-              addRequestUrl={tabRecord.addRequestUrl}
-              addRequestMethod={tabRecord.addRequestMethod}
-              tabId={props.currentTab}
-              addRuleErrorNotify={props.addRuleErrorNotify}
-              addRuleError={props.tabRecord.addRuleError}
+              addRequestDetails={props.addRequestDetails}
+              updateAddRequestFields={props.updateAddRequestFields}
             />
           )}
 
@@ -214,10 +209,12 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
 
 const mapStateToProps = (state: POPUP_PROPS) => {
   return {
-    tabRecord: state.tabRecord[state.currentTab],
-    currentTab: state.currentTab,
-    currentUrl: state.currentUrl,
-    interceptStatus: state.interceptStatus
+    tabRecord: state.rootReducer.tabRecord[state.rootReducer.currentTab],
+    currentTab: state.rootReducer.currentTab,
+    currentUrl: state.rootReducer.currentUrl,
+    interceptStatus: state.rootReducer.interceptStatus,
+    showAddRuleModal: state.rootReducer.showAddRuleModal,
+    addRequestDetails: state.addRequestReducer
   };
 };
 
@@ -233,13 +230,14 @@ const mapDispatchToProps: DispatchProps = {
   fetchResponse: actionTypes.fetchResponse,
   toggleListeningRequests: actionTypes.toggleListeningRequests,
   sendMessageToUI: actionTypes.sendMessageToUI,
-  updateRequest: actionTypes.updateRequest,
-  updateAddRequestMethod: actionTypes.updateAddRequestMethod,
-  updateAddRequestUrl: actionTypes.updateAddRequestUrl,
+  // updateRequest: actionTypes.updateRequest,
+  // updateAddRequestMethod: actionTypes.updateAddRequestMethod,
+  // updateAddRequestUrl: actionTypes.updateAddRequestUrl,
   toggleAddRequestForm: actionTypes.toggleAddRequestForm,
-  handleChangeUrl: actionTypes.handleChangeUrl,
+  // handleChangeUrl: actionTypes.handleChangeUrl,
   fetchFailure: actionTypes.fetchFailure,
-  addRuleErrorNotify: actionTypes.addRuleErrorNotify
+  // addRuleErrorNotify: actionTypes.addRuleErrorNotify,
+  updateAddRequestFields
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Popup);

--- a/app/containers/Popup.tsx
+++ b/app/containers/Popup.tsx
@@ -15,7 +15,7 @@ import { StopIcon } from "../components/Icons/StopIcon";
 
 import { InterceptAllButton } from "./../components/InterceptAllButton";
 import { Switch } from "./../components/Switch";
-import { AddRuleModal } from "./../components/AddRuleModal";
+import AddRuleModal from "./../components/AddRuleModal";
 
 interface DispatchProps {
   errorNotify: typeof actionTypes.errorNotify;
@@ -30,12 +30,9 @@ interface DispatchProps {
   toggleListeningRequests: typeof actionTypes.toggleListeningRequests;
   sendMessageToUI: typeof actionTypes.sendMessageToUI;
   updateRequest: typeof actionTypes.updateRequest;
-  updateAddRequestMethod: typeof actionTypes.updateAddRequestMethod;
-  updateAddRequestUrl: typeof actionTypes.updateAddRequestUrl;
   toggleAddRequestForm: typeof actionTypes.toggleAddRequestForm;
   handleChangeUrl: typeof actionTypes.handleChangeUrl;
   fetchFailure: typeof actionTypes.fetchFailure;
-  addRuleErrorNotify: typeof actionTypes.addRuleErrorNotify;
 }
 
 const CHROME_URL_REGEX = /^chrome:\/\/.+$/;
@@ -184,7 +181,8 @@ export class Popup extends React.Component<POPUP_PROPS & DispatchProps, {}> {
             <AddRuleModal
               handleClose={this.toggleAddRequestForm}
               addRequestDetails={props.addRequestDetails}
-              updateAddRequestFields={props.updateAddRequestFields}
+              updateRequest={props.updateRequest}
+              tabId={props.currentTab}
             />
           )}
 
@@ -230,14 +228,14 @@ const mapDispatchToProps: DispatchProps = {
   fetchResponse: actionTypes.fetchResponse,
   toggleListeningRequests: actionTypes.toggleListeningRequests,
   sendMessageToUI: actionTypes.sendMessageToUI,
-  // updateRequest: actionTypes.updateRequest,
-  // updateAddRequestMethod: actionTypes.updateAddRequestMethod,
-  // updateAddRequestUrl: actionTypes.updateAddRequestUrl,
+  updateRequest: actionTypes.updateRequest,
   toggleAddRequestForm: actionTypes.toggleAddRequestForm,
-  // handleChangeUrl: actionTypes.handleChangeUrl,
+  handleChangeUrl: actionTypes.handleChangeUrl,
   fetchFailure: actionTypes.fetchFailure,
-  // addRuleErrorNotify: actionTypes.addRuleErrorNotify,
   updateAddRequestFields
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Popup);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Popup);

--- a/app/content/content.ts
+++ b/app/content/content.ts
@@ -38,7 +38,7 @@ class Intercept {
     });
   };
   interceptSelected = (message: string, tabId: number) => {
-    const presentState = this.store.getState().tabRecord[tabId];
+    const presentState = this.store.getState().rootReducer.tabRecord[tabId];
     if (!presentState) {
       return;
     }

--- a/app/reducers/addRequest.ts
+++ b/app/reducers/addRequest.ts
@@ -1,0 +1,35 @@
+import { newRequest, Action } from "../types";
+import { RESET, UPDATE_REQUEST_FIELDS, UPDATE_FIELD } from "../actions/addRequest";
+
+const initialState: newRequest = {
+  fields: {
+    url: "",
+    method: ""
+  },
+  errorMessage: ""
+};
+
+export const addRequestReducer = (state = initialState, action: Action) => {
+  switch (action.type) {
+    case UPDATE_REQUEST_FIELDS:
+      return {
+        ...state,
+        fields: {
+          ...state.fields,
+          ...action.payload
+        }
+      };
+    case UPDATE_FIELD:
+      return {
+        ...state,
+        [action.payload.name]: action.payload.value
+      };
+    case RESET:
+      return initialState;
+
+    default:
+      return state;
+  }
+};
+
+export default addRequestReducer;

--- a/app/reducers/addRequest.ts
+++ b/app/reducers/addRequest.ts
@@ -4,9 +4,9 @@ import { RESET, UPDATE_REQUEST_FIELDS, UPDATE_FIELD } from "../actions/addReques
 const initialState: newRequest = {
   fields: {
     url: "",
-    method: ""
-  },
-  errorMessage: ""
+    method: "GET",
+    error: ""
+  }
 };
 
 export const addRequestReducer = (state = initialState, action: Action) => {

--- a/app/reducers/rootReducer.ts
+++ b/app/reducers/rootReducer.ts
@@ -4,13 +4,11 @@ import * as actionType from "../actions";
 export const INITIAL_POPUP_STATE: POPUP_PROPS = {
   tabRecord: {},
   currentUrl: "",
-  currentTab: -1
+  currentTab: -1,
+  showAddRuleModal: false
 };
 
 const initialTabProperties = {
-  showAddRequest: false,
-  addRequestUrl: "",
-  addRequestMethod: "GET",
   enabledStatus: false,
   addRuleError: "",
   requests: [],
@@ -116,32 +114,36 @@ export const reducer = (state = INITIAL_POPUP_STATE, action: Action) => {
         currentTab: action.payload.currentTab,
         interceptStatus: action.payload.interceptStatus
       };
-    case actionType.HANDLE_MODAL_METHOD_CHANGE:
-      return extendTabRecords(state, action.payload, {
-        addRequestMethod: action.payload.value
-      });
-    case actionType.HANDLE_MODAL_URL_CHANGE:
-      return extendTabRecords(state, action.payload, {
-        addRequestUrl: action.payload.value
-      });
+    // case actionType.HANDLE_MODAL_METHOD_CHANGE:
+    //   return extendTabRecords(state, action.payload, {
+    //     addRequestMethod: action.payload.value
+    //   });
+    // case actionType.HANDLE_MODAL_URL_CHANGE:
+    //   return extendTabRecords(state, action.payload, {
+    //     addRequestUrl: action.payload.value
+    //   });
     case actionType.TOGGLE_SHOW_ADD_REQUEST: {
-      return extendTabRecords(state, action.payload, {
-        showAddRequest: action.payload.showAddRequest
-      });
+      return {
+        ...state,
+        showAddRuleModal: action.payload.showAddRuleModal
+      };
+      // return extendTabRecords(state, action.payload, {
+      //   showAddRequest: action.payload.showAddRequest
+      // });
     }
     case actionType.ERROR:
       return extendTabRecords(state, action.payload, {
         errorMessage: action.payload.errorMessage,
         enabledStatus: false
       });
-    case actionType.ADD_RULE_ERROR:
-      return extendTabRecords(state, action.payload, {
-        addRuleError: action.payload.errorMessage
-      });
-    case actionType.CLEAR_REQUESTS:
-      return extendTabRecords(state, action.payload, {
-        requests: []
-      });
+    // case actionType.ADD_RULE_ERROR:
+    //   return extendTabRecords(state, action.payload, {
+    //     addRuleError: action.payload.errorMessage
+    //   });
+    // case actionType.CLEAR_REQUESTS:
+    //   return extendTabRecords(state, action.payload, {
+    //     requests: []
+    //   });
     case actionType.TOGGLE_CHECKBOX:
       return extendTabRecords(state, action.payload, {
         checkedReqs: {

--- a/app/reducers/rootReducer.ts
+++ b/app/reducers/rootReducer.ts
@@ -127,23 +127,16 @@ export const reducer = (state = INITIAL_POPUP_STATE, action: Action) => {
         ...state,
         showAddRuleModal: action.payload.showAddRuleModal
       };
-      // return extendTabRecords(state, action.payload, {
-      //   showAddRequest: action.payload.showAddRequest
-      // });
     }
     case actionType.ERROR:
       return extendTabRecords(state, action.payload, {
         errorMessage: action.payload.errorMessage,
         enabledStatus: false
       });
-    // case actionType.ADD_RULE_ERROR:
-    //   return extendTabRecords(state, action.payload, {
-    //     addRuleError: action.payload.errorMessage
-    //   });
-    // case actionType.CLEAR_REQUESTS:
-    //   return extendTabRecords(state, action.payload, {
-    //     requests: []
-    //   });
+    case actionType.CLEAR_REQUESTS:
+      return extendTabRecords(state, action.payload, {
+        requests: []
+      });
     case actionType.TOGGLE_CHECKBOX:
       return extendTabRecords(state, action.payload, {
         checkedReqs: {

--- a/app/reducers/rootReducer.ts
+++ b/app/reducers/rootReducer.ts
@@ -10,7 +10,6 @@ export const INITIAL_POPUP_STATE: POPUP_PROPS = {
 
 const initialTabProperties = {
   enabledStatus: false,
-  addRuleError: "",
   requests: [],
   errorMessage: "",
   PageDetails: {

--- a/app/store/popup_store.ts
+++ b/app/store/popup_store.ts
@@ -1,9 +1,10 @@
-import { createStore, applyMiddleware, Middleware } from "redux";
+import { createStore, applyMiddleware, Middleware, combineReducers } from "redux";
 import { createLogger } from "redux-logger";
 import thunkMiddleware from "redux-thunk";
 import aliases from "./aliases";
 import { alias } from "react-chrome-redux";
-import { reducer } from "./../reducers/rootReducer";
+import { reducer as rootReducer } from "./../reducers/rootReducer";
+import { addRequestReducer } from "../reducers/addRequest";
 import { POPUP_PROPS } from "../types";
 
 let enhancer: any;
@@ -16,5 +17,5 @@ if (process.env.NODE_ENV !== "production") {
   enhancer = applyMiddleware(alias(aliases), thunkMiddleware);
 }
 export default function(initalState: POPUP_PROPS) {
-  return createStore(reducer, initalState, enhancer);
+  return createStore(combineReducers({ rootReducer, addRequestReducer }), initalState, enhancer);
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -2,12 +2,13 @@ enum interceptStatus {
   Success = "Interception Success!",
   Fail = "Interception Disabled!"
 }
+
 export interface POPUP_PROPS {
   currentTab: number;
   currentUrl: string;
-  interceptStatus: interceptStatus;
+  interceptStatus?: interceptStatus;
   tabRecord: any;
-  requestRecords: any;
+  showAddRuleModal: boolean;
 }
 
 export interface interceptOn {
@@ -26,4 +27,12 @@ export interface Action extends POPUP_PROPS {
 export interface requestListProps extends POPUP_PROPS {
   requests: Array<chrome.webRequest.WebRequestDetails>;
   handleCheckToggle: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export interface newRequest {
+  fields: {
+    url: string;
+    method: string;
+  };
+  errorMessage?: string;
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -33,6 +33,6 @@ export interface newRequest {
   fields: {
     url: string;
     method: string;
+    error?: string;
   };
-  errorMessage?: string;
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "js",
       "jsx"
     ],
+    "testURL": "http://localhost",
     "globals": {
       "__DEV__": true,
       "__RCTProfileIsProfiling": false


### PR DESCRIPTION
- The reducer used earlier was used for all kind of actions. We separated the reducer into `rootReducer` and `addRequestReducer`