### PR TITLE
fix(package.json): remove jest from lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,7 @@
     "linters": {
       "*.{js,jsx,ts,tsx}": [
         "prettier --config .prettierrc --write",
-        "git add",
-        "jest"
+        "git add"
       ]
     },
     "ignore": [


### PR DESCRIPTION
prettier and jest can't run on the same pattern.
it cause jest to run on files with are not test cases.